### PR TITLE
Rewrite other utils using traverseGenerator

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,5 +18,5 @@
 
 9. Add test - traverseGenerator - siblings were traversed earlier, not now. Check input config.
 
-10. Find node by CSS (query language)
+10. Find node by CSS (query language) - Make it work for Class/Function reference also
 11. Helper and filter by props and state

--- a/TODO.md
+++ b/TODO.md
@@ -17,3 +17,5 @@
 
 7. Make it work with older React versions
 8. Make it work with non React-DOM renderers
+
+9. Add test - traverseGenerator - siblings were traversed earlier, not now. Check input config.

--- a/TODO.md
+++ b/TODO.md
@@ -7,8 +7,8 @@
 
 5. Add `findAllNodes` helpers which searches all usages of the components - by name or class
 6. Allow using all methods without explicit root node. Find automatically, if not provided.
-7. SKip siblings for first entry
-8. ** Rewrite `find*` methods using traverseGenerator **
+7. SKip siblings for first entry - DONE
+8. ** Rewrite `find*` methods using traverseGenerator ** - DONE
 
 6. Fix getRootFiberNodeFromDOM and related helpers -
    - .\_internalRoot is not present is 16.0.0 but present in 16.9.0

--- a/TODO.md
+++ b/TODO.md
@@ -7,8 +7,6 @@
 
 5. Add `findAllNodes` helpers which searches all usages of the components - by name or class
 6. Allow using all methods without explicit root node. Find automatically, if not provided.
-7. SKip siblings for first entry - DONE
-8. ** Rewrite `find*` methods using traverseGenerator ** - DONE
 
 6. Fix getRootFiberNodeFromDOM and related helpers -
    - .\_internalRoot is not present is 16.0.0 but present in 16.9.0
@@ -19,3 +17,6 @@
 8. Make it work with non React-DOM renderers
 
 9. Add test - traverseGenerator - siblings were traversed earlier, not now. Check input config.
+
+10. Find node by CSS (query language)
+11. Helper and filter by props and state

--- a/TODO.md
+++ b/TODO.md
@@ -19,4 +19,6 @@
 9. Add test - traverseGenerator - siblings were traversed earlier, not now. Check input config.
 
 10. Find node by CSS (query language) - Make it work for Class/Function reference also
-11. Helper and filter by props and state
+11. Allow easy way to continue FiberNode select with CSS selector for dom node (handling Fragments)
+
+12. Helper and filter by props and state

--- a/src/findNode.ts
+++ b/src/findNode.ts
@@ -38,6 +38,31 @@ function findNodeByComponentName(
   return null;
 }
 
+function* findNodesByComponentName(
+  node: FiberNode | null,
+  expectedName: string,
+  traverseConfig?: TTraverseConfig
+): IterableIterator<FiberNode> {
+  if (node === null) {
+    return null;
+  }
+
+  const nodeIterator = traverseGenerator(node, traverseConfig);
+  for (const tmpNode of nodeIterator) {
+    if (isNodeNotHtmlLike(tmpNode) && tmpNode.type.name === expectedName) {
+      yield tmpNode;
+    }
+  }
+}
+
+function findAllNodesByComponentName(
+  node: FiberNode | null,
+  expectedName: string,
+  traverseConfig?: TTraverseConfig
+): Array<FiberNode> {
+  return [...findNodesByComponentName(node, expectedName, traverseConfig)];
+}
+
 /**
  * Find node by component (i.e. class or function by reference), till first match.
  *
@@ -116,4 +141,10 @@ function findNodeByComponentRef(
   return null;
 }
 
-export { findNodeByComponentName, findNodeByComponent, findNodeByComponentRef };
+export {
+  findNodeByComponentName,
+  findNodesByComponentName,
+  findAllNodesByComponentName,
+  findNodeByComponent,
+  findNodeByComponentRef
+};

--- a/src/findNode.ts
+++ b/src/findNode.ts
@@ -1,4 +1,5 @@
 import { FiberNode } from "./mocked-types";
+import { traverseGenerator, TTraverseConfig } from "./traverse";
 import { isNodeNotHtmlLike } from "./utils";
 
 /**
@@ -20,26 +21,17 @@ import { isNodeNotHtmlLike } from "./utils";
  */
 function findNodeByComponentName(
   node: FiberNode | null,
-  expectedName: string
+  expectedName: string,
+  traverseConfig?: TTraverseConfig
 ): FiberNode | null {
   if (node === null) {
     return null;
   }
 
-  if (isNodeNotHtmlLike(node) && node.type.name === expectedName) {
-    return node;
-  }
-
-  {
-    const returnVal = findNodeByComponentName(node.child, expectedName);
-    if (returnVal !== null) {
-      return returnVal;
-    }
-  }
-  {
-    const returnVal = findNodeByComponentName(node.sibling, expectedName);
-    if (returnVal !== null) {
-      return returnVal;
+  const nodeIterator = traverseGenerator(node, traverseConfig);
+  for (const tmpNode of nodeIterator) {
+    if (isNodeNotHtmlLike(tmpNode) && tmpNode.type.name === expectedName) {
+      return tmpNode;
     }
   }
 
@@ -66,29 +58,20 @@ function findNodeByComponentName(
  */
 function findNodeByComponent(
   node: FiberNode | null,
-  expectedClassOrFunction: React.ComponentType
+  expectedClassOrFunction: React.ComponentType,
+  traverseConfig?: TTraverseConfig
 ): FiberNode | null {
   if (node === null) {
     return null;
   }
 
-  if (isNodeNotHtmlLike(node) && node.type === expectedClassOrFunction) {
-    return node;
-  }
-
-  {
-    const returnVal = findNodeByComponent(node.child, expectedClassOrFunction);
-    if (returnVal !== null) {
-      return returnVal;
-    }
-  }
-  {
-    const returnVal = findNodeByComponent(
-      node.sibling,
-      expectedClassOrFunction
-    );
-    if (returnVal !== null) {
-      return returnVal;
+  const nodeIterator = traverseGenerator(node, traverseConfig);
+  for (const tmpNode of nodeIterator) {
+    if (
+      isNodeNotHtmlLike(tmpNode) &&
+      tmpNode.type === expectedClassOrFunction
+    ) {
+      return tmpNode;
     }
   }
 
@@ -113,29 +96,20 @@ function findNodeByComponent(
  */
 function findNodeByComponentRef(
   node: FiberNode | null,
-  expectedClassInstance: React.Component
+  expectedClassInstance: React.Component,
+  traverseConfig?: TTraverseConfig
 ): FiberNode | null {
   if (node === null) {
     return null;
   }
 
-  if (isNodeNotHtmlLike(node) && node.stateNode === expectedClassInstance) {
-    return node;
-  }
-
-  {
-    const returnVal = findNodeByComponentRef(node.child, expectedClassInstance);
-    if (returnVal !== null) {
-      return returnVal;
-    }
-  }
-  {
-    const returnVal = findNodeByComponentRef(
-      node.sibling,
-      expectedClassInstance
-    );
-    if (returnVal !== null) {
-      return returnVal;
+  const nodeIterator = traverseGenerator(node, traverseConfig);
+  for (const tmpNode of nodeIterator) {
+    if (
+      isNodeNotHtmlLike(tmpNode) &&
+      tmpNode.stateNode === expectedClassInstance
+    ) {
+      return tmpNode;
     }
   }
 

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -2,31 +2,6 @@
 import { FiberNode } from "./mocked-types";
 
 /**
- * Traverse nodes recursively in depth-first manner, starting from a start node.
- *
- * This is the default and basic traversal function, which covers basic use cases.
- * You can't do advanced things like change the order of traversal, skip or cancel traversal after any node, etc.
- * For more advanced usecases, see {@link traverseGenerator}
- *
- * @example
- * ```js
- * // calls fn for each node inside startNode
- * traverse(startNode, fn);
- * ```
- *
- */
-function traverse(node: FiberNode, fn: (node: FiberNode) => any) {
-  fn.call(null, node);
-
-  if (node.child !== null) {
-    traverse(node.child, fn);
-  }
-  if (node.sibling !== null) {
-    traverse(node.sibling, fn);
-  }
-}
-
-/**
  * Traverse nodes recursively using generators.
  *
  * This is the advanced traverse function, which can be used used
@@ -132,6 +107,31 @@ function* traverseGenerator(
   // Now run each generator till end
   for (const eachGen of orderedGenerators) {
     yield* eachGen();
+  }
+}
+
+/**
+ * Traverse nodes recursively in depth-first manner, starting from a start node.
+ *
+ * This is the default and basic traversal function, which covers basic use cases.
+ * You can't do advanced things like change the order of traversal, skip or cancel traversal after any node, etc.
+ * For more advanced usecases, see {@link traverseGenerator}
+ *
+ * @example
+ * ```js
+ * // calls fn for each node inside startNode
+ * traverse(startNode, fn);
+ * ```
+ *
+ */
+function traverse(node: FiberNode, fn: (node: FiberNode) => any) {
+  fn.call(null, node);
+
+  if (node.child !== null) {
+    traverse(node.child, fn);
+  }
+  if (node.sibling !== null) {
+    traverse(node.sibling, fn);
   }
 }
 

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -63,11 +63,15 @@ import { FiberNode } from "./mocked-types";
 function* traverseGenerator(
   node: FiberNode,
   {
-    order = ["self", "child", "sibling"]
-  }: { order?: Array<"self" | "child" | "sibling"> } = {}
+    order = ["self", "child", "sibling"],
+    skipSiblingForStartNode = true
+  }: {
+    order?: Array<"self" | "child" | "sibling">;
+    skipSiblingForStartNode?: boolean;
+  } = {}
 ): IterableIterator<FiberNode> {
   let skipChild = false,
-    skipSibling = false;
+    skipSibling = skipSiblingForStartNode;
 
   function* traverseSelf() {
     const controlInput:
@@ -82,14 +86,20 @@ function* traverseGenerator(
   function* traverseChild() {
     if (!skipChild && node.child !== null) {
       const nextNode = node.child;
-      yield* traverseGenerator(nextNode, { order });
+      yield* traverseGenerator(nextNode, {
+        order,
+        skipSiblingForStartNode: false
+      });
     }
   }
 
   function* traverseSibling() {
     if (!skipSibling && node.sibling !== null) {
       const nextNode = node.sibling;
-      yield* traverseGenerator(nextNode, { order });
+      yield* traverseGenerator(nextNode, {
+        order,
+        skipSiblingForStartNode: false
+      });
     }
   }
 

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -125,13 +125,9 @@ function* traverseGenerator(
  *
  */
 function traverse(node: FiberNode, fn: (node: FiberNode) => any) {
-  fn.call(null, node);
-
-  if (node.child !== null) {
-    traverse(node.child, fn);
-  }
-  if (node.sibling !== null) {
-    traverse(node.sibling, fn);
+  const nodeIterator = traverseGenerator(node);
+  for (const tmpNode of nodeIterator) {
+    fn.call(null, tmpNode);
   }
 }
 

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -1,6 +1,11 @@
 // import { isNodeSimple } from './utils';
 import { FiberNode } from "./mocked-types";
 
+interface TTraverseConfig {
+  order?: Array<"self" | "child" | "sibling">;
+  skipSiblingForStartNode?: boolean;
+}
+
 /**
  * Traverse nodes recursively using generators.
  *
@@ -65,10 +70,7 @@ function* traverseGenerator(
   {
     order = ["self", "child", "sibling"],
     skipSiblingForStartNode = true
-  }: {
-    order?: Array<"self" | "child" | "sibling">;
-    skipSiblingForStartNode?: boolean;
-  } = {}
+  }: TTraverseConfig = {}
 ): IterableIterator<FiberNode> {
   let skipChild = false,
     skipSibling = skipSiblingForStartNode;
@@ -141,4 +143,4 @@ function traverse(node: FiberNode, fn: (node: FiberNode) => any) {
   }
 }
 
-export { traverse, traverseGenerator };
+export { traverse, traverseGenerator, TTraverseConfig };

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -136,8 +136,12 @@ function* traverseGenerator(
  * ```
  *
  */
-function traverse(node: FiberNode, fn: (node: FiberNode) => any) {
-  const nodeIterator = traverseGenerator(node);
+function traverse(
+  node: FiberNode,
+  fn: (node: FiberNode) => any,
+  traverseConfig?: TTraverseConfig
+) {
+  const nodeIterator = traverseGenerator(node, traverseConfig);
   for (const tmpNode of nodeIterator) {
     fn.call(null, tmpNode);
   }


### PR DESCRIPTION
## Rationale -
All other utils shouldn't need to know about fiber tree structure - that is already encapsulated within traverseGenerator.

### Changes -
So, they can be simplified by using it for traversal - 
a. For find*, only check node code needs to be different.
b. For traverse, just loop over generator.

Check -
a. Tests -
 * Nothing broke ??
 * Add tests for traverseConfig everywhere

b. Is prev logic for other utils intact?